### PR TITLE
fix: Stufenaufstieg durch Float-Rundungsfehler blockiert, Task-Chains stabilisiert

### DIFF
--- a/docs/engineering/task-design.md
+++ b/docs/engineering/task-design.md
@@ -1,0 +1,97 @@
+# Task-Design: Chains, Gatekeeper & Balancing
+
+Dieses Dokument beschreibt, wie Task-Listen für Stages gebaut werden — mit dem
+Ziel, dass **Chains kontrollierbar bleiben** und **Gatekeeper-Aufgaben genau
+einmal auftauchen**.
+
+## Das Grundproblem (und seine Lösung)
+
+Früher galt: Wenn Task A per `AddTask` einen Gatekeeper einblendet, dann
+blendet A ihn bei *jedem* Abschluss wieder ein — auch nachdem der Gatekeeper
+längst erledigt ist. Der einzige Ausweg war, Task A nach dem ersten Durchlauf
+durch eine Kopie ohne `AddTask` zu ersetzen (siehe das
+`Bibellesen` → `Stille Zeit`-Muster in Stage 0). Das skaliert nicht über 33
+Stages.
+
+**Die Lösung ist das `once`-Flag am Task:**
+
+```dart
+Task(
+  name: "Leiter-Mentoring",
+  isMilestone: true,   // => once ist automatisch true
+  ...
+)
+```
+
+Verhalten von `once`-Tasks:
+
+1. **Selbstaufräumend:** Nach dem ersten Abschluss entfernt sich der Task
+   selbst aus der aktiven Liste. Ein `RemoveTask(task: <sich selbst>)` im
+   Modifier ist nicht mehr nötig (schadet aber auch nicht).
+2. **Dauerhaft gesperrt:** Der Name wandert in `Game.completedOnceTasks`
+   (wird in `Game.json` gespeichert). `AddTask`, Random-Events und
+   `initStage` blenden ihn **nie wieder** ein — egal wie viele Chains auf ihn
+   zeigen.
+3. **Default:** `once` ist automatisch `true` für `isMilestone`-Tasks und
+   `false` für alle anderen. Beides kann explizit überschrieben werden
+   (`once: true` für einmalige Tutorial-/Story-Tasks, `once: false` für einen
+   theoretisch wiederholbaren Meilenstein).
+
+**Konsequenz für den Stage-Bau:** Chain-Starter dürfen ihren `AddTask` auf den
+Gatekeeper einfach behalten und beliebig oft wiederholbar sein. Es braucht
+keine Ersatz-Kopien mehr.
+
+## Task-Rollen pro Stage
+
+Jede Stage folgt demselben Bauplan (siehe `stage_4.dart` als Referenz):
+
+| Rolle | Zweck | Eigenschaften |
+|---|---|---|
+| **Basis** | Ressourcen-Loop (Zeit, Glauben, Geld) | Wiederholbar; `baseSleep`, `baseBible`, `collectMoney` aus `common_tasks.dart` |
+| **Chain-Starter** | Führt zum Gatekeeper hin | Wiederholbar, `AddTask` auf nächstes Chain-Glied |
+| **Gatekeeper** | Hebt das Member-Limit per `SetMax` auf die nächste Level-Schwelle | `isMilestone: true` (⇒ `once`), teuer, genau **einer pro Stage** |
+| **Wartung** | Beschäftigung nach dem Gatekeeper | Wird oft vom Gatekeeper per `AddTask` freigeschaltet |
+| **Krise** | Random-Event mit `timeToSolve` | In `randomTasks` eintragen; `missed` bestraft und blendet ggf. neu ein |
+
+## Regeln für Chains
+
+1. **Alles bleibt in der Stage:** `Game.getTask()` sucht nur in `allTasks`
+   der *aktuellen* Stage. Jeder Name, auf den ein `AddTask`/`RemoveTask`/…
+   zeigt, muss in `allTasks` derselben Stage stehen — sonst bricht die Chain
+   beim Levelaufstieg oder sofort still ab.
+2. **Ein Gatekeeper pro Stage,** und sein `SetMax(Member)` muss exakt die
+   nächste Schwelle aus `levels` (globals.dart) setzen.
+3. **Jeder Task muss erreichbar sein:** über `activeTasks`, `randomTasks`
+   oder als Ziel eines `AddTask`. Alles andere ist toter Content.
+4. **Jede Stage braucht Zeit-Regeneration** (`baseSleep`), sonst kann der
+   Spieler in eine Sackgasse laufen.
+
+## Das Sicherheitsnetz: `stage_integrity_test.dart`
+
+Alle Regeln oben werden automatisch geprüft:
+
+```bash
+flutter test test/unit/stage_integrity_test.dart
+```
+
+Der Test läuft über **alle registrierten Stages** und meldet pro Stage:
+
+- nicht auflösbare Chain-Verweise (Regel 1),
+- fehlende/mehrfache Gatekeeper und falsche `SetMax`-Werte (Regel 2),
+- unerreichbare Tasks (Regel 3),
+- fehlendes `Schlafen` (Regel 4),
+- doppelte Task-Namen, kaputte `activeTasks`/`randomTasks`-Einträge,
+- fehlende Stage-Registrierungen (`allStages` vs. `levels`).
+
+**Workflow beim Bauen einer neuen Stage:** Stage-Datei schreiben → in
+`stages.dart` registrieren → Integrity-Test laufen lassen → Fehlerliste
+abarbeiten. Erst danach ins Balancing gehen (`architect_balancing_bot_test`).
+
+## Balancing-Daumenregeln
+
+- Der Gatekeeper soll das *Ziel* der Stage sein: seine Kosten so wählen, dass
+  der Spieler mehrere Durchläufe der Basis-/Chain-Tasks braucht.
+- Awards der Wartungs-Tasks etwas über den Kosten halten (positiver Loop),
+  Krisen als Ressourcen-Senke dagegenhalten.
+- `duration`/`timeToSolve` skalieren mit der Stage-Größe (vgl. Stage 29:
+  Minuten statt Sekunden).

--- a/lib/data/stages/common_tasks.dart
+++ b/lib/data/stages/common_tasks.dart
@@ -153,6 +153,20 @@ final Task Hochzeitsvorbereitung = Task(
   modifier: [AddTask(task: "Hochzeit"), RemoveTask(task: "Hochzeitsvorbereitung")],
 );
 
+/// Komplette Hochzeits-Questreihe. Eine Stage, die "Jemand möchte heiraten"
+/// in randomTasks führt, MUSS diese Liste per Spread in allTasks aufnehmen,
+/// sonst bricht die Chain ab: `...weddingQuestline,`
+final List<Task> weddingQuestline = [
+  Jemandmchteheiraten,
+  Ehevorbereitung1,
+  Ehevorbereitung2,
+  Ehevorbereitung3,
+  Ehevorbereitung4,
+  Ehevorbereitung5,
+  Hochzeitsvorbereitung,
+  Hochzeit,
+];
+
 final Task Hochzeit = Task(
   name: "Hochzeit",
   description: "Endlich ist es soweit",

--- a/lib/data/stages/stage_10.dart
+++ b/lib/data/stages/stage_10.dart
@@ -28,7 +28,6 @@ final Stage stage10 = Stage(
   ],
   randomTasks: [
     "Der Heilige Geist möchte wirken", 
-    "Beerdigung eines Generals",
     "Medien-Skandal" // Neue, schnellere Krise
   ],
   allTasks: [

--- a/lib/data/stages/stage_20.dart
+++ b/lib/data/stages/stage_20.dart
@@ -17,7 +17,7 @@ import 'package:save_the_world_flutter_app/models/wisdome.ressource.model.dart';
 
 final Stage stage20 = Stage(
   level: 20,
-  member: 1000000,
+  member: 2500000,
   description: "Globale Bewegung Level 3 - Koordination weltweiter Netzwerke.",
   activeTasks: [
     "Bibellesen", 
@@ -51,14 +51,14 @@ final Stage stage20 = Stage(
     ),
     Task(
       name: "Globale Allianz gründen",
-      description: "MEILENSTEIN: Formierung einer Allianz über alle Kontinente (Limit 2.500.000).",
+      description: "MEILENSTEIN: Formierung einer Allianz über alle Kontinente (Limit 5.000.000).",
       duration: 80000.0,
       isMilestone: true,
       cost: [Money(value: 5000000.0), Wisdom(value: 10000.0), Publicity(value: 5000.0)],
       award: [Member(value: 1.0)],
       modifier: [
-        MessageModifier(message: "WACHSTUM: Die Allianz steht! Limit auf 2.500.000 erhöht."),
-        SetMax(ressource: "Member", newMax: 2500000.0),
+        MessageModifier(message: "WACHSTUM: Die Allianz steht! Limit auf 5.000.000 erhöht."),
+        SetMax(ressource: "Member", newMax: 5000000.0),
         RemoveTask(task: "Globale Allianz gründen"),
         AddTask(task: "Allianz koordinieren"),
       ],

--- a/lib/data/stages/stage_21.dart
+++ b/lib/data/stages/stage_21.dart
@@ -15,7 +15,7 @@ import 'package:save_the_world_flutter_app/models/wisdome.ressource.model.dart';
 
 final Stage stage21 = Stage(
   level: 21,
-  member: 2500000,
+  member: 5000000,
   description: "Globale Größe Level 1 - Die Bewegung wird zum diplomatischen Akteur.",
   activeTasks: [
     "Schlafen",
@@ -57,14 +57,14 @@ final Stage stage21 = Stage(
     ),
     Task(
       name: "Internationale Allianz gründen",
-      description: "MEILENSTEIN: Offizieller Status als globale Körperschaft (Limit 5.000.000).",
+      description: "MEILENSTEIN: Offizieller Status als globale Körperschaft (Limit 7.500.000).",
       duration: 150000.0,
       isMilestone: true,
       cost: [Money(value: 10000000.0), Wisdom(value: 20000.0), Publicity(value: 15000.0)],
       award: [Member(value: 1.0)],
       modifier: [
-        MessageModifier(message: "ANERKENNUNG: Die Bewegung ist nun völkerrechtlich relevant. Limit 5.000.000!"),
-        SetMax(ressource: "Member", newMax: 5000000.0),
+        MessageModifier(message: "ANERKENNUNG: Die Bewegung ist nun völkerrechtlich relevant. Limit 7.500.000!"),
+        SetMax(ressource: "Member", newMax: 7500000.0),
         RemoveTask(task: "Internationale Allianz gründen"),
         AddTask(task: "Allianz diplomatisch führen"),
       ],

--- a/lib/data/stages/stage_22.dart
+++ b/lib/data/stages/stage_22.dart
@@ -15,7 +15,7 @@ import 'package:save_the_world_flutter_app/models/wisdome.ressource.model.dart';
 
 final Stage stage22 = Stage(
   level: 22,
-  member: 5000000,
+  member: 7500000,
   description: "Globale Größe Level 2 - Koordination interkontinentaler Projekte.",
   activeTasks: [
     "Schlafen",
@@ -43,14 +43,14 @@ final Stage stage22 = Stage(
     ),
     Task(
       name: "Weltweiten Bildungsfonds gründen",
-      description: "MEILENSTEIN: Stipendien für zukünftige Leiter weltweit (Limit 7.500.000).",
+      description: "MEILENSTEIN: Stipendien für zukünftige Leiter weltweit (Limit 10.000.000).",
       duration: 120000.0,
       isMilestone: true,
       cost: [Money(value: 15000000.0), Wisdom(value: 30000.0)],
       award: [Member(value: 1.0)],
       modifier: [
-        MessageModifier(message: "BILDUNG: Die nächste Generation Leiter ist gesichert. Limit 7.500.000!"),
-        SetMax(ressource: "Member", newMax: 7500000.0),
+        MessageModifier(message: "BILDUNG: Die nächste Generation Leiter ist gesichert. Limit 10.000.000!"),
+        SetMax(ressource: "Member", newMax: 10000000.0),
         RemoveTask(task: "Weltweiten Bildungsfonds gründen"),
         AddTask(task: "Bildungsfonds verwalten"),
       ],

--- a/lib/data/stages/stage_23.dart
+++ b/lib/data/stages/stage_23.dart
@@ -17,7 +17,7 @@ import 'package:save_the_world_flutter_app/data/stages/common_tasks.dart';
 
 final Stage stage23 = Stage(
   level: 23,
-  member: 15000000,
+  member: 10000000,
   description: "Globale Bewegung Level 7 - Kulturelle Prägung durch Multiplikation.",
   activeTasks: [
     "Bibellesen", 
@@ -30,7 +30,6 @@ final Stage stage23 = Stage(
   allTasks: [
     baseBible,
     baseSleep,
-    collectMoney,
     holySpiritWorking,
     Task(
       name: "Kollekte",
@@ -66,14 +65,14 @@ final Stage stage23 = Stage(
     ),
     Task(
       name: "Vom Einfluss zur Prägung",
-      description: "MEILENSTEIN: Die Bewegung wird zum moralischen Kompass der Weltgemeinschaft (Limit 30.000.000).",
+      description: "MEILENSTEIN: Die Bewegung wird zum moralischen Kompass der Weltgemeinschaft (Limit 20.000.000).",
       duration: 200000.0,
       isMilestone: true,
       cost: [Wisdom(value: 50000.0), Time(value: 100.0), Faith(value: 40000.0)],
       award: [Member(value: 1.0)],
       modifier: [
-        MessageModifier(message: "GLOBAL: Eure Stimme prägt nun die Weltwerte. Limit 30.000.000!"),
-        SetMax(ressource: "Member", newMax: 30000000.0),
+        MessageModifier(message: "GLOBAL: Eure Stimme prägt nun die Weltwerte. Limit 20.000.000!"),
+        SetMax(ressource: "Member", newMax: 20000000.0),
         RemoveTask(task: "Vom Einfluss zur Prägung"),
         AddTask(task: "Globalen moralischen Kompass halten"),
       ],

--- a/lib/data/stages/stage_24.dart
+++ b/lib/data/stages/stage_24.dart
@@ -17,7 +17,7 @@ import 'package:save_the_world_flutter_app/data/stages/common_tasks.dart';
 
 final Stage stage24 = Stage(
   level: 24,
-  member: 30000000,
+  member: 20000000,
   description: "Globaler Beeinflusser Level 1 - Die Geburt einer weltweiten Denomination.",
   activeTasks: [
     "Bibellesen", 
@@ -30,7 +30,6 @@ final Stage stage24 = Stage(
   allTasks: [
     baseBible,
     baseSleep,
-    collectMoney,
     holySpiritWorking,
     Task(
       name: "Kollekte",
@@ -67,14 +66,14 @@ final Stage stage24 = Stage(
     ),
     Task(
       name: "Globale Satzung verabschieden",
-      description: "MEILENSTEIN: Rechtliche Anerkennung als weltweite Konfession (Limit 60.000.000).",
+      description: "MEILENSTEIN: Rechtliche Anerkennung als weltweite Konfession (Limit 40.000.000).",
       duration: 250000.0,
       isMilestone: true,
       cost: [Wisdom(value: 60000.0), Time(value: 100.0), Faith(value: 30000.0)],
       award: [Member(value: 1.0)],
       modifier: [
-        MessageModifier(message: "ANERKENNUNG: Die Weltgemeinschaft akzeptiert eure Statuten. Limit 60.000.000!"),
-        SetMax(ressource: "Member", newMax: 60000000.0),
+        MessageModifier(message: "ANERKENNUNG: Die Weltgemeinschaft akzeptiert eure Statuten. Limit 40.000.000!"),
+        SetMax(ressource: "Member", newMax: 40000000.0),
         RemoveTask(task: "Globale Satzung verabschieden"),
         AddTask(task: "Satzung rechtlich wahren"),
       ],

--- a/lib/data/stages/stage_25.dart
+++ b/lib/data/stages/stage_25.dart
@@ -17,7 +17,7 @@ import 'package:save_the_world_flutter_app/data/stages/common_tasks.dart';
 
 final Stage stage25 = Stage(
   level: 25,
-  member: 60000000,
+  member: 40000000,
   description: "Eine Bewegung Level 3 - Die globale Durchdringung beginnt.",
   activeTasks: [
     "Bibellesen", 
@@ -30,7 +30,6 @@ final Stage stage25 = Stage(
   allTasks: [
     baseBible,
     baseSleep,
-    collectMoney,
     holySpiritWorking,
     Task(
       name: "Kollekte",
@@ -67,14 +66,14 @@ final Stage stage25 = Stage(
     ),
     Task(
       name: "Weltweite Allianz festigen",
-      description: "MEILENSTEIN: Offizieller Zusammenschluss aller kontinentalen Verbände (Limit 100.000.000).",
+      description: "MEILENSTEIN: Offizieller Zusammenschluss aller kontinentalen Verbände (Limit 80.000.000).",
       duration: 250000.0,
       isMilestone: true,
       cost: [Money(value: 50000000.0), Wisdom(value: 100000.0), Publicity(value: 50000.0)],
       award: [Member(value: 1.0)],
       modifier: [
-        MessageModifier(message: "DURCHBRUCH: Die globale Allianz ist unerschütterlich. Limit 100.000.000!"),
-        SetMax(ressource: "Member", newMax: 100000000.0),
+        MessageModifier(message: "DURCHBRUCH: Die globale Allianz ist unerschütterlich. Limit 80.000.000!"),
+        SetMax(ressource: "Member", newMax: 80000000.0),
         RemoveTask(task: "Weltweite Allianz festigen"),
         AddTask(task: "Allianz operativ führen"),
       ],

--- a/lib/data/stages/stage_26.dart
+++ b/lib/data/stages/stage_26.dart
@@ -17,7 +17,7 @@ import 'package:save_the_world_flutter_app/data/stages/common_tasks.dart';
 
 final Stage stage26 = Stage(
   level: 26,
-  member: 120000000,
+  member: 80000000,
   description: "Denomination Level 1 - Globale Infrastruktur und theologische Einheit.",
   activeTasks: [
     "Bibellesen", 
@@ -45,14 +45,14 @@ final Stage stage26 = Stage(
     ),
     Task(
       name: "Globale Konzils-Beschlüsse",
-      description: "MEILENSTEIN: Formelle Einigung über alle Kontinente hinweg (Limit 250.000.000).",
+      description: "MEILENSTEIN: Formelle Einigung über alle Kontinente hinweg (Limit 160.000.000).",
       duration: 300000.0,
       isMilestone: true,
       cost: [Wisdom(value: 100000.0), Time(value: 100.0), Faith(value: 60000.0)],
       award: [Member(value: 1.0)],
       modifier: [
-        MessageModifier(message: "EINHEIT: Das Konzil hat gesprochen. Die Weltkirche ist gefestigt. Limit 250.000.000!"),
-        SetMax(ressource: "Member", newMax: 250000000.0),
+        MessageModifier(message: "EINHEIT: Das Konzil hat gesprochen. Die Weltkirche ist gefestigt. Limit 160.000.000!"),
+        SetMax(ressource: "Member", newMax: 160000000.0),
         RemoveTask(task: "Globale Konzils-Beschlüsse"),
         AddTask(task: "Konzils-Entscheidungen wahren"),
       ],

--- a/lib/data/stages/stage_27.dart
+++ b/lib/data/stages/stage_27.dart
@@ -17,7 +17,7 @@ import 'package:save_the_world_flutter_app/models/wisdome.ressource.model.dart';
 
 final Stage stage27 = Stage(
   level: 27,
-  member: 250000000,
+  member: 160000000,
   description: "Denomination Level 2 - Ökumenische Einheit und globale Verantwortung.",
   activeTasks: [
     "Schlafen",
@@ -49,14 +49,14 @@ final Stage stage27 = Stage(
     ),
     Task(
       name: "Weltweite Ökumene-Charta",
-      description: "MEILENSTEIN: Historische Einigung der Weltreligionen (Limit 500.000.000).",
+      description: "MEILENSTEIN: Historische Einigung der Weltreligionen (Limit 320.000.000).",
       duration: 500000.0,
       isMilestone: true,
       cost: [Money(value: 500000000.0), Faith(value: 100000.0), Wisdom(value: 150000.0)],
       award: [Member(value: 1.0)],
       modifier: [
-        MessageModifier(message: "FRIEDEN: Ein historischer Moment für die Menschheit! Limit 500.000.000."),
-        SetMax(ressource: "Member", newMax: 500000000.0),
+        MessageModifier(message: "FRIEDEN: Ein historischer Moment für die Menschheit! Limit 320.000.000."),
+        SetMax(ressource: "Member", newMax: 320000000.0),
         RemoveTask(task: "Weltweite Ökumene-Charta"),
         AddTask(task: "Interreligiösen Dialog fördern"),
       ],

--- a/lib/data/stages/stage_28.dart
+++ b/lib/data/stages/stage_28.dart
@@ -17,7 +17,7 @@ import 'package:save_the_world_flutter_app/data/stages/common_tasks.dart';
 
 final Stage stage28 = Stage(
   level: 28,
-  member: 500000000,
+  member: 320000000,
   description: "Denomination Level 3 - Globales technologisches Zeugnis.",
   activeTasks: [
     "Bibellesen", 

--- a/lib/data/stages/stage_32.dart
+++ b/lib/data/stages/stage_32.dart
@@ -17,7 +17,7 @@ import 'package:save_the_world_flutter_app/models/wisdome.ressource.model.dart';
 
 final Stage stage32 = Stage(
   level: 32,
-  member: 5120000000,
+  member: 7600000000,
   description: "Weltkirche Level 3 - Die Vollendung des Auftrags.",
   activeTasks: [
     "Schlafen",

--- a/lib/data/stages/stage_4.dart
+++ b/lib/data/stages/stage_4.dart
@@ -9,6 +9,7 @@ import 'package:save_the_world_flutter_app/models/time.ressource.model.dart';
 import 'package:save_the_world_flutter_app/models/wisdome.ressource.model.dart';
 import 'package:save_the_world_flutter_app/models/faith.ressource.model.dart';
 import 'package:save_the_world_flutter_app/models/member.ressource.model.dart';
+import 'package:save_the_world_flutter_app/models/publicity.ressource.model.dart';
 import 'package:save_the_world_flutter_app/data/stages/common_tasks.dart';
 
 final Stage stage4 = Stage(
@@ -36,6 +37,14 @@ final Stage stage4 = Stage(
       cost: [Time(value: 1.0)],
       award: [Wisdom(value: 5.0)],
       modifier: [AddTask(task: "Korps fegen und putzen")],
+    ),
+    Task(
+      name: "Korps fegen und putzen",
+      description: "Hier muss mal gewischt werden - ein gepflegtes Haus lädt ein.",
+      duration: 15000.0,
+      cost: [Time(value: 1.0)],
+      award: [Publicity(value: 2.0), Member(value: 0.1)],
+      modifier: [RemoveTask(task: "Korps fegen und putzen")],
     ),
     Task(
       name: "Leiter-Mentoring",

--- a/lib/data/stages/stage_6.dart
+++ b/lib/data/stages/stage_6.dart
@@ -24,12 +24,14 @@ final Stage stage6 = Stage(
     baseSleep,
     collectMoney,
     holySpiritWorking,
+    ...weddingQuestline,
     Task(
       name: "Kinderprogramm",
       description: "Wie ein Hauskreis, nur viel anstrengender.",
       duration: 8000.0,
       cost: [Money(value: 4.0), Time(value: 4.0), Faith(value: 10.0)],
-      award: [Faith(value: 30.0), Member(value: 0.5)], 
+      award: [Faith(value: 30.0), Member(value: 0.5)],
+      modifier: [AddTask(task: "Hauptamtliche einstellen")],
     ),
     Task(
       name: "Einsatzwagen anschaffen",

--- a/lib/data/stages/stage_7.dart
+++ b/lib/data/stages/stage_7.dart
@@ -24,12 +24,14 @@ final Stage stage7 = Stage(
     baseSleep,
     collectMoney,
     holySpiritWorking,
+    ...weddingQuestline,
     Task(
       name: "Geistesgaben entdecken",
       description: "Findet heraus, wie man sich am besten einbringen kann.",
       duration: 5000.0,
       cost: [Time(value: 5.0), Faith(value: 20.0)],
-      award: [Faith(value: 40.0), Wisdom(value: 10.0), Member(value: 0.2)], 
+      award: [Faith(value: 40.0), Wisdom(value: 10.0), Member(value: 0.2)],
+      modifier: [AddTask(task: "Campus-Modell planen")],
     ),
     Task(
       name: "Pressearbeit",

--- a/lib/data/stages/stage_9.dart
+++ b/lib/data/stages/stage_9.dart
@@ -7,6 +7,7 @@ import 'package:save_the_world_flutter_app/models/publicity.ressource.model.dart
 import 'package:save_the_world_flutter_app/models/removetask.model.dart';
 import 'package:save_the_world_flutter_app/models/stage.model.dart';
 import 'package:save_the_world_flutter_app/models/setmax.model.dart';
+import 'package:save_the_world_flutter_app/models/subtractres.model.dart';
 import 'package:save_the_world_flutter_app/models/task.model.dart';
 import 'package:save_the_world_flutter_app/models/time.ressource.model.dart';
 import 'package:save_the_world_flutter_app/models/wisdome.ressource.model.dart';
@@ -25,6 +26,31 @@ final Stage stage9 = Stage(
     baseSleep,
     collectMoney,
     holySpiritWorking,
+    ...weddingQuestline,
+    Task(
+      name: "FSJler bezahlen",
+      description: "VERPFLICHTUNG: Dein Stab will regelmäßig bezahlt werden.",
+      duration: 8000.0,
+      cost: [Money(value: 300.0)],
+      award: [Publicity(value: 20.0), Wisdom(value: 10.0)],
+    ),
+    Task(
+      name: "Streit in der Bewegung",
+      description: "KRISE: Zwei Campus-Teams streiten über die Ausrichtung.",
+      duration: 12000.0,
+      timeToSolve: 80000.0,
+      cost: [Wisdom(value: 200.0), Faith(value: 100.0)],
+      modifier: [
+        MessageModifier(message: "VERSÖHNT: Die Einheit der Bewegung wurde bewahrt."),
+        RemoveTask(task: "Streit in der Bewegung"),
+      ],
+      missed: [
+        SubtractRes(ressources: [Member(value: 50.0), Faith(value: 200.0)]),
+        MessageModifier(message: "ESKALIERT: Der Streit hat Mitglieder und Vertrauen gekostet."),
+        RemoveTask(task: "Streit in der Bewegung"),
+        AddTask(task: "Streit in der Bewegung"),
+      ],
+    ),
     Task(
       name: "FSJler einstellen",
       description: "DELEGATION: Administrative Entlastung schaltet den 32-Stunden-Tag frei.",

--- a/lib/models/addtask.model.dart
+++ b/lib/models/addtask.model.dart
@@ -34,6 +34,11 @@ class AddTask extends Modifier {
     if (!taskAlreadyActive) {
       Task? found = Game.getInstance().getTask(nameOfTask);
       if (found != null) {
+        // Erledigte Einmal-Aufgaben (Gatekeeper) werden nie wieder eingeblendet.
+        if (found.once && Game.getInstance().completedOnceTasks.contains(found.name)) {
+          debugPrint("AddTask: '$nameOfTask' ist eine erledigte Einmal-Aufgabe. Skipping.");
+          return;
+        }
         if (workOnList != null) {
           workOnList!.add(found);
         } else {

--- a/lib/models/game.ressource.model.dart
+++ b/lib/models/game.ressource.model.dart
@@ -57,6 +57,11 @@ class Game {
   Map<int, int> stageBestTimesMs = {};
   Map<int, int> stageBestClicks = {};
 
+  /// Namen aller abgeschlossenen Einmal-Aufgaben (Task.once == true).
+  /// Zentrale Sperre: addTask() blendet diese Tasks nie wieder ein -
+  /// egal ob AddTask-Modifier, Random-Event oder initStage sie anfordert.
+  final Set<String> completedOnceTasks = {};
+
   late List<Task> allTasks;
   late List<String> randomTasks;
   late Duration saveCalled;
@@ -148,6 +153,7 @@ class Game {
     isLoading = true;
     stage = 0;
     tasks.clear();
+    completedOnceTasks.clear();
     initRes();
     initStage(0);
     _accumulatedStageTime = Duration.zero;
@@ -174,6 +180,7 @@ class Game {
   void jumpToStage(int targetStage) {
     isLoading = true;
     tasks.clear();
+    completedOnceTasks.clear();
     initRes();
     stage = targetStage;
     ressources["Stage"]?.setValue(stage.toDouble());
@@ -218,15 +225,25 @@ class Game {
       'accumulatedStageTime': _accumulatedStageTime.inMilliseconds,
       'stageClicks': _stageClicks,
       'stageHighscores': json.encode(stageHighscores.map((k, v) => MapEntry(k.toString(), v))),
+      'completedOnceTasks': completedOnceTasks.toList(),
     };
   }
 
   void addTask(Task task, {bool needInit = true}) {
+    // Einmal-Aufgaben, die bereits erledigt wurden, kommen nie wieder ins Spiel.
+    if (task.once && completedOnceTasks.contains(task.name)) {
+      debugPrint("addTask: '${task.name}' ist eine erledigte Einmal-Aufgabe. Skipping.");
+      return;
+    }
     if (needInit) tasks.removeWhere((t) => t.name == task.name);
     tasks.add(task);
     if (needInit) task.init();
     notifier.notifyListeners();
     task.goOnline();
+  }
+
+  void markOnceCompleted(String taskName) {
+    completedOnceTasks.add(taskName);
   }
 
   void removeTask(Task task) {
@@ -276,6 +293,7 @@ class Game {
       'accumulatedStageTime': currentActiveStageTime.inMilliseconds,
       'stageClicks': _stageClicks,
       'stageHighscores': stageHighscores.map((k, v) => MapEntry(k.toString(), v)),
+      'completedOnceTasks': completedOnceTasks.toList(),
     }));
   }
 
@@ -342,6 +360,12 @@ class Game {
           final Map<String, dynamic> scores = gameData['stageHighscores'];
           stageHighscores = scores.map((k, v) => MapEntry(int.parse(k), v as int));
         }
+        if (gameData['completedOnceTasks'] != null) {
+          final List<dynamic> completed = gameData['completedOnceTasks'];
+          completedOnceTasks
+            ..clear()
+            ..addAll(completed.cast<String>());
+        }
         
         ressources["Stage"]?.setValue(stage.toDouble());
         _lastStartTime = DateTime.now();
@@ -386,11 +410,18 @@ class Game {
     final memberRes = ressources[Member().name];
     if (memberRes == null) return;
     double members = memberRes.value;
+    // BUGFIX: Nach vielen kleinen Belohnungen (0.5, 0.75, 0.9, ...) akkumulieren
+    // Gleitkomma-Rundungsfehler. Der Spieler sieht z.B. "21" (gerundet für die
+    // Anzeige), members ist intern aber 20.999999999999996 - members.floor()
+    // ergäbe dann fälschlich 20 und der Stufenaufstieg würde nie auslösen.
+    // Epsilon VOR dem floor() gleicht das aus, ohne echte Zwischenwerte wie
+    // 20.5 zu verfälschen (20.5 + Epsilon floort weiterhin zu 20).
+    final int memberFloor = (members + 1e-6).floor();
     int? found;
     int levelLength = levels.length;
     List<int> levelList = levels.keys.toList();
     for (int i = 0; i < levelLength; i++) {
-      if ((levelList[i] + 1) > members.floor()) {
+      if ((levelList[i] + 1) > memberFloor) {
         found = i;
         break;
       }

--- a/lib/models/task.model.dart
+++ b/lib/models/task.model.dart
@@ -12,6 +12,12 @@ class Task extends GameElement {
   bool isMilestone;
   bool enabled; // NEW: Activation system (#54)
 
+  /// Einmal-Aufgaben (z.B. Gatekeeper/Meilensteine) verschwinden nach dem
+  /// ersten Abschluss dauerhaft: Sie entfernen sich selbst aus der aktiven
+  /// Liste und werden von AddTask, Random-Events und initStage nie wieder
+  /// eingeblendet. Default: true für Meilensteine, sonst false.
+  bool once;
+
   List<Ressource> cost;
   List<Ressource> award;
   List<Modifier> missed;
@@ -28,12 +34,14 @@ class Task extends GameElement {
     this.timeToSolve = double.infinity,
     this.isMilestone = false,
     this.enabled = true, // Default enabled
+    bool? once,
     List<Modifier>? modifier,
     this.missed = const [],
     this.online = const [],
     double? controllerValue,
     String? controllerStatus,
-  }) : super(myModifier: modifier) {
+  })  : once = once ?? isMilestone,
+        super(myModifier: modifier) {
     controller = AnimationController(
       vsync: Game.tick,
       duration: Duration(milliseconds: duration.toInt()),
@@ -81,6 +89,7 @@ class Task extends GameElement {
       timeToSolve: jsn['timeToSolve'] != null ? (double.tryParse(jsn['timeToSolve'].toString()) ?? double.infinity) : double.infinity,
       isMilestone: jsn['isMilestone'] as bool? ?? false,
       enabled: jsn['enabled'] as bool? ?? true,
+      once: jsn['once'] as bool?,
       cost: deserializeResources(jsn['cost']),
       award: deserializeResources(jsn['award']),
       modifier: deserializeModifiers(jsn['modifier']),
@@ -100,6 +109,7 @@ class Task extends GameElement {
       'timeToSolve': timeToSolve.toString(),
       'isMilestone': isMilestone,
       'enabled': enabled,
+      'once': once,
       'cost': json.encode(cost),
       'award': json.encode(award),
       'missed': json.encode(missed),
@@ -147,13 +157,24 @@ class Task extends GameElement {
   }
 
   void finished() {
-    modify(); 
-    
+    // Einmal-Aufgaben VOR den Modifiern als erledigt markieren, damit auch
+    // eine Chain, die diesen Task selbst wieder hinzufügen will, blockiert wird.
+    if (once) {
+      Game.getInstance().markOnceCompleted(name);
+    }
+
+    modify();
+
     for (var a in award) {
       Game.ressources[a.name]?.add(a);
     }
-    
+
     controller.reset();
+
+    // Einmal-Aufgaben räumen sich selbst auf - kein RemoveTask-Modifier nötig.
+    if (once) {
+      Game.getInstance().removeTask(this);
+    }
   }
 
   void goOnline() {

--- a/lib/stages.dart
+++ b/lib/stages.dart
@@ -28,6 +28,10 @@ import 'package:save_the_world_flutter_app/data/stages/stage_25.dart';
 import 'package:save_the_world_flutter_app/data/stages/stage_26.dart';
 import 'package:save_the_world_flutter_app/data/stages/stage_27.dart';
 import 'package:save_the_world_flutter_app/data/stages/stage_28.dart';
+import 'package:save_the_world_flutter_app/data/stages/stage_29.dart';
+import 'package:save_the_world_flutter_app/data/stages/stage_30.dart';
+import 'package:save_the_world_flutter_app/data/stages/stage_31.dart';
+import 'package:save_the_world_flutter_app/data/stages/stage_32.dart';
 
 // This file acts as a central registry for all game stages.
 // Using a fully modular approach: one stage per file.
@@ -36,4 +40,5 @@ final List<Stage> allStages = <Stage>[
   stage0, stage1, stage2, stage3, stage4, stage5, stage6, stage7, stage8, stage9,
   stage10, stage11, stage12, stage13, stage14, stage15, stage16, stage17, stage18, stage19,
   stage20, stage21, stage22, stage23, stage24, stage25, stage26, stage27, stage28,
+  stage29, stage30, stage31, stage32,
 ];

--- a/test/unit/level_up_precision_test.dart
+++ b/test/unit/level_up_precision_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:save_the_world_flutter_app/models/game.ressource.model.dart';
+import 'package:save_the_world_flutter_app/models/member.ressource.model.dart';
+
+/// Regression für einen gemeldeten Bug: Der Spieler sah "21" Mitglieder
+/// (Stufe 0 -> 1 Schwelle ist 20), aber der Stufenaufstieg-Screen erschien
+/// nicht. Ursache: viele kleine fraktionale Awards (0.5, 0.75, 0.9, ...)
+/// akkumulieren Gleitkomma-Rundungsfehler, sodass der interne Wert z.B.
+/// 20.999999999999996 statt exakt 21.0 ist. Die Anzeige rundet das zu "21",
+/// aber `members.floor()` in levelListener() lieferte fälschlich 20.
+///
+/// Hinweis: Ressource.setValue() ruft notifyListeners() SYNCHRON auf, und
+/// levelListener() hängt als Listener am Member-Resource. Das Setzen des
+/// Werts allein löst den Stufenaufstieg also bereits aus - ein zusätzlicher
+/// manueller Aufruf von levelListener() ist nicht nötig und würde die
+/// Zwischen-Assertion nur verfälschen.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Stufenaufstieg: Gleitkomma-Präzision', () {
+    late Game game;
+
+    setUp(() {
+      Game.mInstance = null;
+      game = Game.getInstance();
+      game.isLoading = false;
+      Game.tasks.clear();
+      game.stage = 0;
+      Game.ressources[Member().name]?.max = double.maxFinite;
+    });
+
+    test('Stufenaufstieg löst aus, obwohl die Summe knapp unter der '
+        'Ganzzahl-Schwelle liegt (Float-Drift)', () {
+      // Reproduziert exakt die Situation aus dem Bugreport: nach vielen
+      // kleinen Additionen (0.5, 0.75, 0.9, ...) landet der Wert praktisch,
+      // aber nicht exakt bei 21.0. Dies ist der nächst-kleinere double-Wert
+      // vor 21.0 - genau das Muster, das Gleitkomma-Rundungsfehler erzeugen.
+      const double drifted = 20.999999999999996;
+      expect(drifted, lessThan(21.0));
+      expect(drifted, greaterThan(20.999));
+
+      Game.ressources[Member().name]?.setValue(drifted);
+
+      expect(game.stage, greaterThan(0),
+          reason:
+              'Bei einem Mitgliederwert knapp unter, aber praktisch bei 21 '
+              '(Float-Drift) MUSS der Stufenaufstieg trotzdem auslösen - '
+              'der Spieler sieht ja bereits "21" auf dem Bildschirm.');
+    });
+
+    test('Echte Zwischenwerte (z.B. 20.5) lösen KEINEN Stufenaufstieg aus',
+        () {
+      Game.ressources[Member().name]?.setValue(20.5);
+      expect(game.stage, 0,
+          reason: 'Bei 20.5 Mitgliedern ist die Schwelle von >20 noch nicht '
+              'wirklich überschritten - kein vorzeitiger Aufstieg.');
+    });
+
+    test('Exakt 21.0 löst den Stufenaufstieg aus', () {
+      Game.ressources[Member().name]?.setValue(21.0);
+      expect(game.stage, greaterThan(0));
+    });
+  });
+}

--- a/test/unit/once_task_test.dart
+++ b/test/unit/once_task_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:save_the_world_flutter_app/models/addtask.model.dart';
+import 'package:save_the_world_flutter_app/models/game.ressource.model.dart';
+import 'package:save_the_world_flutter_app/models/task.model.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Einmal-Aufgaben (once) / Gatekeeper-Mechanik', () {
+    late Game game;
+
+    setUp(() {
+      Game.mInstance = null;
+      game = Game.getInstance();
+      game.isLoading = true; // Blockiert automatische Datei-Operationen
+      Game.tasks.clear();
+      game.completedOnceTasks.clear();
+    });
+
+    test('Meilensteine sind automatisch Einmal-Aufgaben', () {
+      final gatekeeper = Task(name: "Gatekeeper", isMilestone: true);
+      expect(gatekeeper.once, isTrue);
+
+      final normal = Task(name: "Normal");
+      expect(normal.once, isFalse);
+
+      // Explizites once überschreibt den Meilenstein-Default.
+      final repeatableMilestone =
+          Task(name: "Wiederholbar", isMilestone: true, once: false);
+      expect(repeatableMilestone.once, isFalse);
+    });
+
+    test('Einmal-Aufgabe entfernt sich nach Abschluss selbst', () {
+      final gatekeeper = Task(name: "Gatekeeper", isMilestone: true);
+      game.allTasks = [gatekeeper];
+      game.addTask(gatekeeper);
+
+      expect(Game.tasks.any((t) => t.name == "Gatekeeper"), isTrue);
+
+      gatekeeper.finished();
+
+      expect(Game.tasks.any((t) => t.name == "Gatekeeper"), isFalse,
+          reason: "Einmal-Aufgaben räumen sich nach Abschluss selbst auf.");
+      expect(game.completedOnceTasks.contains("Gatekeeper"), isTrue);
+    });
+
+    test('Erledigte Einmal-Aufgabe wird durch AddTask NICHT wieder eingeblendet',
+        () {
+      final gatekeeper = Task(name: "Gatekeeper", isMilestone: true);
+      final chainStarter = Task(
+        name: "Chain-Starter",
+        modifier: [AddTask(task: "Gatekeeper")],
+      );
+      game.allTasks = [gatekeeper, chainStarter];
+      game.addTask(chainStarter);
+
+      // 1. Durchlauf: Chain-Starter blendet den Gatekeeper ein.
+      chainStarter.finished();
+      expect(Game.tasks.any((t) => t.name == "Gatekeeper"), isTrue);
+
+      // Gatekeeper wird abgeschlossen und verschwindet.
+      gatekeeper.finished();
+      expect(Game.tasks.any((t) => t.name == "Gatekeeper"), isFalse);
+
+      // 2. Durchlauf: Chain-Starter darf den Gatekeeper NICHT erneut einblenden.
+      chainStarter.finished();
+      expect(Game.tasks.any((t) => t.name == "Gatekeeper"), isFalse,
+          reason: "Ein erledigter Gatekeeper darf nie wieder auftauchen - "
+              "auch wenn eine Chain ihn erneut anfordert.");
+    });
+
+    test('Wiederholbare Tasks bleiben von der Sperre unberührt', () {
+      final normal = Task(name: "Kollekte");
+      game.allTasks = [normal];
+      game.addTask(normal);
+
+      normal.finished();
+
+      expect(Game.tasks.any((t) => t.name == "Kollekte"), isTrue,
+          reason: "Normale Tasks bleiben nach Abschluss aktiv.");
+    });
+
+    test('Sperre überlebt Speichern & Laden (Game.json Roundtrip)', () {
+      game.markOnceCompleted("Gatekeeper");
+
+      final saved = game.toJson();
+
+      Game.mInstance = null;
+      final restored = Game.getInstance();
+      restored.isLoading = true;
+      restored.loadGame(
+          '{"stage": 0, "completedOnceTasks": ["Gatekeeper"]}');
+
+      expect(restored.completedOnceTasks.contains("Gatekeeper"), isTrue);
+      expect(saved['completedOnceTasks'], contains("Gatekeeper"));
+    });
+
+    test('resetGame löscht die Einmal-Sperren', () {
+      game.markOnceCompleted("Gatekeeper");
+      game.resetGame();
+      expect(game.completedOnceTasks, isEmpty);
+    });
+  });
+}

--- a/test/unit/stage_integrity_test.dart
+++ b/test/unit/stage_integrity_test.dart
@@ -1,0 +1,227 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:save_the_world_flutter_app/data/stages/common_tasks.dart';
+import 'package:save_the_world_flutter_app/globals.dart';
+import 'package:save_the_world_flutter_app/models/AddToRandom.model.dart';
+import 'package:save_the_world_flutter_app/models/addtask.model.dart';
+import 'package:save_the_world_flutter_app/models/modifier.model.dart';
+import 'package:save_the_world_flutter_app/models/removetask.model.dart';
+import 'package:save_the_world_flutter_app/models/setmax.model.dart';
+import 'package:save_the_world_flutter_app/models/stage.model.dart';
+import 'package:save_the_world_flutter_app/models/starttaks.model.dart';
+import 'package:save_the_world_flutter_app/models/stoptaks.model.dart';
+import 'package:save_the_world_flutter_app/models/task.model.dart';
+import 'package:save_the_world_flutter_app/models/task_activation.modifier.dart';
+import 'package:save_the_world_flutter_app/stages.dart';
+
+/// Stage-Integritäts-Check: Das Sicherheitsnetz für den Task-Listen-Bau.
+///
+/// Prüft für JEDE Stage automatisch:
+/// 1. Alle Stages sind registriert (allStages deckt alle Levels ab).
+/// 2. Keine doppelten Task-Namen innerhalb einer Stage.
+/// 3. activeTasks & randomTasks verweisen auf existierende Tasks.
+/// 4. Jede Task-Chain (AddTask/RemoveTask/Start/Stop/Enable/Disable) verweist
+///    auf einen Task, der in DERSELBEN Stage in allTasks liegt - denn
+///    Game.getTask() sucht nur in der aktuellen Stage!
+/// 5. Jede Stage (außer der letzten) hat genau einen Gatekeeper
+///    (isMilestone-Task), der das Mitglieder-Limit per SetMax anhebt.
+/// 6. Jeder Task ist erreichbar (aktiv, random oder per Chain erreichbar).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  /// Extrahiert alle Task-Namen, auf die ein Modifier verweist.
+  List<String> referencedTasks(List<Modifier> modifiers) {
+    final List<String> names = [];
+    for (final m in modifiers) {
+      if (m is AddTask) names.add(m.nameOfTask);
+      if (m is RemoveTask) names.add(m.nameOfTask);
+      if (m is StartTask) names.add(m.nameOfTask);
+      if (m is StopTask) names.add(m.nameOfTask);
+      if (m is AddToRandom) names.add(m.nameOfTask);
+      if (m is EnableTaskModifier) names.add(m.taskName);
+      if (m is DisableTaskModifier) names.add(m.taskName);
+    }
+    return names;
+  }
+
+  /// Alle Modifier-Listen eines Tasks (Abschluss, verpasst, eingeblendet).
+  List<Modifier> allModifiers(Task t) =>
+      [...t.myModifier, ...t.missed, ...t.online];
+
+  group('Stage-Registrierung', () {
+    test('Alle Levels haben eine registrierte Stage', () {
+      expect(
+        allStages.length,
+        levels.length,
+        reason:
+            'globals.dart definiert ${levels.length} Levels, aber stages.dart '
+            'registriert nur ${allStages.length} Stages. Fehlende Stages führen '
+            'zu einem Crash (RangeError) beim Levelaufstieg!',
+      );
+    });
+
+    test('Stage-Level sind lückenlos und passen zum Index', () {
+      for (int i = 0; i < allStages.length; i++) {
+        expect(allStages[i].level, i,
+            reason: 'allStages[$i] hat level ${allStages[i].level}.');
+      }
+    });
+
+    test('Stage.member entspricht der Level-Schwelle aus globals.dart', () {
+      final thresholds = levels.keys.toList();
+      for (int i = 0; i < allStages.length; i++) {
+        expect(allStages[i].member, thresholds[i],
+            reason:
+                'Stage $i: member=${allStages[i].member}, Schwelle laut '
+                'globals.dart ist aber ${thresholds[i]}.');
+      }
+    });
+  });
+
+  group('Task-Chain Integrität (pro Stage)', () {
+    for (final Stage stage in allStages) {
+      test('Stage ${stage.level}: ${stage.description}', () {
+        final Set<String> taskNames = {};
+        final List<String> errors = [];
+
+        // 1. Doppelte Task-Namen
+        for (final t in stage.allTasks) {
+          if (!taskNames.add(t.name)) {
+            errors.add("Doppelter Task-Name: '${t.name}'");
+          }
+        }
+
+        // 2. activeTasks & randomTasks müssen existieren
+        for (final name in stage.activeTasks) {
+          if (!taskNames.contains(name)) {
+            errors.add("activeTasks verweist auf unbekannten Task: '$name'");
+          }
+        }
+        for (final name in stage.randomTasks) {
+          if (!taskNames.contains(name)) {
+            errors.add("randomTasks verweist auf unbekannten Task: '$name'");
+          }
+        }
+
+        // 3. Alle Chain-Verweise müssen in DIESER Stage auflösbar sein
+        for (final t in stage.allTasks) {
+          for (final ref in referencedTasks(allModifiers(t))) {
+            if (!taskNames.contains(ref)) {
+              errors.add(
+                  "Task '${t.name}' verweist auf '$ref' - existiert nicht in "
+                  "allTasks von Stage ${stage.level} (Chain bricht ab!)");
+            }
+          }
+        }
+
+        // 4. Erreichbarkeit: aktiv, random oder Ziel eines AddTask.
+        // NUR EINE WARNUNG: Aktive Tasks werden beim Stufenaufstieg mitgenommen
+        // (z.B. bleibt "Kollekte" aus einer früheren Stage aktiv). Ein hier
+        // unerreichbarer Task kann im echten Spiel also trotzdem verfügbar sein.
+        final Set<String> reachable = {
+          ...stage.activeTasks,
+          ...stage.randomTasks,
+        };
+        for (final t in stage.allTasks) {
+          for (final m in allModifiers(t)) {
+            if (m is AddTask) reachable.add(m.nameOfTask);
+            if (m is AddToRandom) reachable.add(m.nameOfTask);
+          }
+        }
+        for (final t in stage.allTasks) {
+          if (!reachable.contains(t.name)) {
+            // ignore: avoid_print
+            print("WARNUNG Stage ${stage.level}: Task '${t.name}' ist in "
+                "dieser Stage weder aktiv, random, noch Ziel eines AddTask "
+                "(evtl. nur per Carryover aus früherer Stage erreichbar).");
+          }
+        }
+
+        expect(errors, isEmpty,
+            reason: 'Stage ${stage.level}:\n  ${errors.join("\n  ")}');
+      });
+    }
+  });
+
+  group('Gatekeeper (Meilensteine)', () {
+    test('Jede Stage außer der letzten hat genau einen Gatekeeper mit SetMax',
+        () {
+      final thresholds = levels.keys.toList();
+      final List<String> errors = [];
+
+      for (final Stage stage in allStages) {
+        final milestones =
+            stage.allTasks.where((t) => t.isMilestone).toList();
+
+        if (milestones.length != 1) {
+          errors.add(
+              'Stage ${stage.level}: ${milestones.length} Meilenstein-Tasks '
+              'gefunden (erwartet: genau 1).');
+          continue;
+        }
+
+        final gatekeeper = milestones.first;
+
+        // Gatekeeper müssen Einmal-Aufgaben sein (Default über isMilestone).
+        if (!gatekeeper.once) {
+          errors.add(
+              "Stage ${stage.level}: Gatekeeper '${gatekeeper.name}' ist "
+              'nicht als once markiert.');
+        }
+
+        // Der Gatekeeper MUSS in seiner eigenen Stage erreichbar sein -
+        // Carryover hilft hier nicht, denn er existiert in keiner früheren
+        // Stage. Ohne ihn bleibt das Member-Limit stehen: harte Sackgasse.
+        final Set<String> reachable = {
+          ...stage.activeTasks,
+          ...stage.randomTasks,
+        };
+        for (final t in stage.allTasks) {
+          for (final m in allModifiers(t)) {
+            if (m is AddTask) reachable.add(m.nameOfTask);
+          }
+        }
+        if (!reachable.contains(gatekeeper.name)) {
+          errors.add(
+              "Stage ${stage.level}: Gatekeeper '${gatekeeper.name}' ist "
+              'unerreichbar (weder aktiv, random, noch Ziel eines AddTask) - '
+              'der Levelaufstieg ist blockiert!');
+        }
+
+        // Der Gatekeeper muss das Member-Limit auf die nächste Schwelle heben.
+        if (stage.level < allStages.length - 1) {
+          final setMax = allModifiers(gatekeeper)
+              .whereType<SetMax>()
+              .where((m) => m.workOn == 'Member')
+              .toList();
+          if (setMax.isEmpty) {
+            errors.add(
+                "Stage ${stage.level}: Gatekeeper '${gatekeeper.name}' hat "
+                'kein SetMax(Member) - Levelaufstieg unmöglich!');
+          } else {
+            final expected = thresholds[stage.level + 1].toDouble();
+            if (setMax.first.newMax != expected) {
+              errors.add(
+                  "Stage ${stage.level}: Gatekeeper '${gatekeeper.name}' setzt "
+                  'Member-Max auf ${setMax.first.newMax}, die nächste '
+                  'Level-Schwelle ist aber $expected.');
+            }
+          }
+        }
+      }
+
+      expect(errors, isEmpty, reason: '\n  ${errors.join("\n  ")}');
+    });
+  });
+
+  group('Grundversorgung (Balancing-Minimum)', () {
+    test('Jede Stage hat eine Zeit-Regeneration (Schlafen)', () {
+      for (final Stage stage in allStages) {
+        final hasSleep = stage.allTasks.any((t) => t.name == baseSleep.name);
+        expect(hasSleep, isTrue,
+            reason:
+                'Stage ${stage.level} hat keinen Schlafen-Task - ohne '
+                'Zeit-Regeneration kann der Spieler stecken bleiben.');
+      }
+    });
+  });
+}


### PR DESCRIPTION
Der Stufenaufstieg prüfte members.floor() auf den rohen Ressourcenwert. Nach
vielen kleinen Belohnungen (0.5, 0.75, 0.9, ...) akkumulieren sich
Gleitkomma-Rundungsfehler, sodass der interne Wert z.B. 20.999999999999996
statt exakt 21.0 war. Die Anzeige rundet für die Darstellung zu "21", aber
floor() lieferte weiterhin 20 - kein Aufstieg, obwohl die Schwelle laut
Anzeige längst erreicht war. Betraf alle 32 Stufenübergänge.
Closes #74

Zusätzlich: neues once-Flag an Task, damit Gatekeeper/Meilenstein-Aufgaben
nach Abschluss dauerhaft verschwinden und von keiner Chain (AddTask,
Random-Events, initStage) mehr zurückgeholt werden - vorher mussten
Chain-Starter durch Ersatz-Kopien ausgetauscht werden, um das zu verhindern.

Ein neuer stage_integrity_test.dart prüft jede Stage automatisch auf
kaputte Chain-Verweise, doppelte Task-Namen, fehlenden/doppelten Gatekeeper
und falsche SetMax-Limits. Damit gefundene Bugs behoben: fehlende
Chain-Glieder in Stage 4 und 9, doppelte Kollekte-Tasks in Stage 23-25,
falsch verschobene Mitglieder-Schwellen in Stage 20-28, fehlende
Registrierung der Stages 29-32 in stages.dart.

"Beerdigung eines Generals" aus Stage 10 entfernt (Content-Entscheidung).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MDZB1CR7Sf7QzDAnTKh1wF