### PR TITLE
Stufenaufstieg bleibt nach Reset/Stage-Sprung dauerhaft hängen

### DIFF
--- a/lib/models/game.ressource.model.dart
+++ b/lib/models/game.ressource.model.dart
@@ -92,7 +92,9 @@ class Game {
     randCalled = const Duration(seconds: 0);
     
     initStage(this.stage);
-    ressources[Member().name]?.addListener(levelListener);
+    // initRes() (oben) haengt levelListener bereits an - kein zweites
+    // addListener hier, sonst wuerde der Listener doppelt registriert und
+    // bei jeder Aenderung zweimal feuern.
     loadState();
     
     resumeStageTimer();
@@ -144,9 +146,20 @@ class Game {
     ressources[Publicity().name] = Publicity(value: 1.0);
     ressources[Wisdom().name] = Wisdom(value: 10.0);
     ressources["Stage"] = StageRes(value: stage.toDouble());
-    
+
     ressources[Member().name]?.max = 20.0;
     ressources[Member().name]?.min = 0.0;
+
+    // BUGFIX: initRes() ERSETZT das Member-Ressourcen-Objekt komplett durch
+    // eine neue Instanz. resetGame() und jumpToStage() rufen initRes() nach
+    // der Konstruktion erneut auf - der levelListener, der nur EINMAL im
+    // Konstruktor an das damalige Objekt angehängt wurde, haengt danach an
+    // einem verworfenen Objekt und feuert nie wieder. Der Spieler bleibt
+    // dann dauerhaft in Stage/LVL 0 haengen, egal wie hoch Member steigt.
+    // Deshalb hier bei JEDEM initRes()-Aufruf neu anhängen (removeListener
+    // ist ein No-Op, falls der Listener am neuen Objekt noch nicht existiert).
+    ressources[Member().name]?.removeListener(levelListener);
+    ressources[Member().name]?.addListener(levelListener);
   }
 
   void resetGame() {
@@ -297,18 +310,30 @@ class Game {
     }));
   }
 
-  void loadState() async {
+  Future<void> loadState() async {
     isLoading = true;
     final resJsn = await dataManager.readData("gameRes");
     loadRes(resJsn);
-    
+
     final allTasksJsn = await dataManager.readData("allTasks");
     await loadAllTasks(allTasksJsn);
-    
+
     final gameJsn = await dataManager.readData("Game");
     loadGame(gameJsn);
-    
+
     isLoading = false;
+
+    // BUGFIX: levelListener() haengt als Listener am Member-Ressourcen-Objekt
+    // und wird deshalb schon WAEHREND loadRes() ausgeloest (setValue() ruft
+    // notifyListeners() auf) - zu diesem Zeitpunkt ist isLoading aber noch
+    // true, also bricht levelListener() sofort ab. Ein gespeicherter Stand,
+    // der (z.B. durch einen frueheren Bug) bereits eine zur Mitgliederzahl
+    // nicht mehr passende Stage enthaelt, wuerde dadurch NIE nachtraeglich
+    // korrigiert - der Spieler bliebe dauerhaft in der falschen Stage
+    // haengen, obwohl der Stufenaufstieg-Fix fuer NEUE Faelle laengst greift.
+    // Expliziter Nachtrag hier holt das nach, sobald isLoading wieder false ist.
+    levelListener();
+
     notifier.notifyListeners();
     stagenNotifier.notifyListeners();
   }

--- a/test/unit/reset_levelup_test.dart
+++ b/test/unit/reset_levelup_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:save_the_world_flutter_app/models/game.ressource.model.dart';
+import 'package:save_the_world_flutter_app/models/member.ressource.model.dart';
+
+/// Regression für einen vom Nutzer gemeldeten Bug: Nach Drücken des
+/// "Reset"-Buttons (resetGame()) blieb der Stufenaufstieg für den Rest der
+/// Sitzung komplett aus, egal wie hoch die Mitgliederzahl stieg.
+///
+/// Ursache: initRes() ERSETZT das Member-Ressourcen-Objekt durch eine neue
+/// Instanz. Der levelListener war aber nur EINMAL im Konstruktor an das
+/// ursprüngliche Objekt angehängt - nach resetGame() (das initRes() erneut
+/// aufruft) hing der Listener am verworfenen alten Objekt und feuerte nie
+/// wieder.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Stufenaufstieg nach resetGame() / jumpToStage()', () {
+    tearDown(() {
+      Game.mInstance?.dispose();
+      Game.mInstance = null;
+    });
+
+    test('Stufenaufstieg funktioniert nach resetGame() weiterhin', () {
+      Game.mInstance = null;
+      final game = Game.getInstance();
+      game.isLoading = false;
+
+      game.resetGame();
+      expect(game.stage, 0, reason: 'Vorbedingung: Reset landet in Stage 0.');
+
+      // Simuliert normales Spielen NACH dem Reset: Mitglieder wachsen über
+      // die Stage-0-Schwelle (20) hinaus.
+      Game.ressources[Member().name]?.setValue(25.0);
+
+      expect(
+        game.stage,
+        greaterThan(0),
+        reason: 'Nach einem Reset muss der Stufenaufstieg weiterhin '
+            'auslösen, sobald die Mitgliederzahl die Schwelle übersteigt - '
+            'sonst bleibt der Spieler für den Rest der Sitzung in Stage 0 '
+            'hängen, egal wie hoch die Mitgliederzahl steigt.',
+      );
+    });
+
+    test('Stufenaufstieg funktioniert nach jumpToStage() weiterhin', () {
+      Game.mInstance = null;
+      final game = Game.getInstance();
+      game.isLoading = false;
+
+      game.jumpToStage(2);
+      expect(game.stage, 2, reason: 'Vorbedingung: Sprung nach Stage 2.');
+
+      // Mitgliederzahl über die Stage-2-Schwelle (80) hinaus wachsen lassen.
+      Game.ressources[Member().name]?.setValue(85.0);
+
+      expect(
+        game.stage,
+        greaterThan(2),
+        reason: 'Auch nach jumpToStage() muss der Stufenaufstieg-Listener '
+            'weiterhin am aktuellen Member-Objekt hängen.',
+      );
+    });
+  });
+}

--- a/test/unit/stale_save_levelup_test.dart
+++ b/test/unit/stale_save_levelup_test.dart
@@ -1,0 +1,85 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:save_the_world_flutter_app/data_manager.dart';
+import 'package:save_the_world_flutter_app/models/game.ressource.model.dart';
+
+/// Ersetzt echte Datei-/Plugin-Zugriffe durch fest verdrahtete JSON-Antworten,
+/// damit loadState() kontrolliert mit einem präparierten (kaputten)
+/// Spielstand getestet werden kann.
+class _FakeDataManager extends DataManager {
+  final Map<String, String?> data;
+  _FakeDataManager(this.data);
+
+  @override
+  Future<String?> readData(String fileName) async => data[fileName];
+
+  @override
+  Future<void> writeJson(String fileName, String jsonString) async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Stufenaufstieg-Nachholung bei fehlerhaftem/alten Spielstand', () {
+    tearDown(() {
+      Game.mInstance?.dispose();
+      Game.mInstance = null;
+    });
+
+    test('loadState() korrigiert eine Stage, die nicht mehr zur '
+        'gespeicherten Mitgliederzahl passt', () async {
+      Game.mInstance = null;
+      final game = Game.getInstance();
+
+      // Simuliert exakt den Bug aus dem Screenshot: Ein (z.B. durch einen
+      // früheren Fehler) gespeicherter Stand zeigt Stage 0, obwohl die
+      // gespeicherte Mitgliederzahl (24.3) die Stage-0-Schwelle (20) längst
+      // überschritten hat.
+      final resJson = json.encode({
+        'Member': {'value': 24.3, 'min': 1.0, 'max': 20.0},
+      });
+      final gameJson = json.encode({'stage': 0});
+
+      game.dataManager = _FakeDataManager({
+        'gameRes': resJson,
+        'allTasks': null,
+        'Game': gameJson,
+      });
+
+      await game.loadState();
+
+      expect(game.isLoading, isFalse);
+      expect(
+        game.stage,
+        greaterThan(0),
+        reason: 'Ein gespeicherter Stand mit Member=24.3 aber Stage=0 muss '
+            'beim Laden nachträglich korrigiert werden - sonst bleibt der '
+            'Spieler dauerhaft in der falschen Stage haengen, selbst nachdem '
+            'der Stufenaufstieg-Bug fuer NEUE Faelle laengst gefixt ist.',
+      );
+    });
+
+    test('loadState() lässt einen konsistenten Spielstand unangetastet', () async {
+      Game.mInstance = null;
+      final game = Game.getInstance();
+
+      final resJson = json.encode({
+        'Member': {'value': 15.0, 'min': 1.0, 'max': 20.0},
+      });
+      final gameJson = json.encode({'stage': 0});
+
+      game.dataManager = _FakeDataManager({
+        'gameRes': resJson,
+        'allTasks': null,
+        'Game': gameJson,
+      });
+
+      await game.loadState();
+
+      expect(game.stage, 0,
+          reason: 'Ein konsistenter Stand (Member unter der Schwelle) darf '
+              'nicht faelschlich vorzeitig aufsteigen.');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Root Cause für den im Screenshot gemeldeten Bug (LVL 0 trotz 24,3 Mitgliedern, weit über der Stage-0-Schwelle von 20): der bestehende Stufenaufstieg-Fix aus #76 (Float-Rundungsfehler) ist korrekt und bereits live deployed - der hier gemeldete Fall hat eine **andere, eigenständige** Ursache.

Zwei Bugs gefunden und behoben:

1. **`initRes()` ersetzt das Member-Ressourcen-Objekt komplett** durch eine neue Instanz. `levelListener()` war aber nur EINMAL im Konstruktor an das ursprüngliche Objekt angehängt. `resetGame()` und `jumpToStage()` rufen `initRes()` nach der Konstruktion erneut auf - der Listener hing danach an einem verworfenen Objekt und feuerte nie wieder, egal wie hoch die Mitgliederzahl stieg. **Betraf jeden Reset-Button-Klick** - genau das, was der Nutzer laut eigener Aussage getan hat. Fix: `initRes()` hängt den Listener bei jedem Aufruf selbst neu an.
2. **`levelListener()` prüft `if (isLoading) return;`**, wird aber schon während `loadRes()` ausgelöst (bevor `isLoading` wieder `false` wird) und danach nie erneut geprüft. Ein gespeicherter Stand mit bereits inkonsistenter Stage/Mitgliederzahl-Kombination würde dadurch nie nachträglich korrigiert. Fix: expliziter `levelListener()`-Aufruf in `loadState()`, nachdem `isLoading` wieder `false` ist.

`loadState()` gibt jetzt `Future<void>` statt `void` zurück (vorher nicht awaitbar, nötig für kontrolliertes Testen) - rein additiv, bestehende Aufrufer bleiben gültig.

## Test plan

- [x] Neuer Test `reset_levelup_test.dart`: Stufenaufstieg nach `resetGame()` und nach `jumpToStage()` - beide schlagen ohne den Fix nachweislich fehl (Gegenprobe durchgeführt), sind mit Fix grün.
- [x] Neuer Test `stale_save_levelup_test.dart`: `loadState()` korrigiert einen inkonsistenten gespeicherten Stand (Gegenprobe durchgeführt).
- [x] Bestehende Suite (`level_up_precision_test`, `game_logic_test`, `modifier_test`, `modifier_chain_test`, `resource_test`) weiterhin grün.
- [ ] Manuelles Nachstellen im Browser (Reset drücken, weiterspielen bis über die Schwelle) steht noch aus.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MDZB1CR7Sf7QzDAnTKh1wF)_